### PR TITLE
Do not blow up on long sequences of empty tokens

### DIFF
--- a/regexp-lexer.js
+++ b/regexp-lexer.js
@@ -406,11 +406,10 @@ RegExpLexer.prototype = {
     // return next match that has a token
     lex: function lex () {
         var r = this.next();
-        if (r) {
-            return r;
-        } else {
-            return this.lex();
+        while(!r) {
+            r = this.next()
         }
+        return r;
     },
 
     // activates a new lexer condition state (pushes the new lexer condition state onto the condition stack)

--- a/tests/regexplexer.js
+++ b/tests/regexplexer.js
@@ -1019,3 +1019,29 @@ exports["test yytext state after unput"] = function() {
     assert.equal(lexer.lex(), "NUMBER");
     assert.equal(lexer.lex(), "EOF");
 };
+
+exports["test not blowing up on a sequence of ignored tockens the size of the maximum callstack size"] = function() {
+    var dict = {
+        rules: [
+            ["#", "// ignored" ],
+            ["$", "return 'EOF';"]
+        ]
+    };
+
+    /**
+     * Crafts a src string of `#`s for our rules the size of the current maximum callstack.
+     * The lexer used to blow up with a stack overflow error in this case.
+     */
+    var makeStackBlowingHashes = function() {
+        try {
+            return "#" + makeStackBlowingHashes();
+        } catch (e) {
+            return "#";
+        }
+    };
+
+    var input = makeStackBlowingHashes();
+
+    var lexer = new RegExpLexer(dict, input);
+    assert.equal(lexer.lex(), "EOF");
+};


### PR DESCRIPTION
Replace the recursive search for a non-empty token with an iterative approach to allow lexing arbitrarily long sequences of empty tokens (rather than blowing up when the sequence of ignored tokens reach the maximum size of the callstack).